### PR TITLE
Break a refencence cycle in destroy

### DIFF
--- a/js/Flotr.Graph.js
+++ b/js/Flotr.Graph.js
@@ -51,6 +51,7 @@ Flotr.Graph.prototype = {
       E.stopObserving.apply(this, handle);
     });
     this._handles = [];
+    this.el.graph = null;
   },
 
   _observe: function (object, name, callback) {


### PR DESCRIPTION
Break the reference cycle between the graph and its element in the destroy function which will would prevent garbage collection if there is no new graph created with this element.
