### PR TITLE
Fix calculateTicks for Firefox

### DIFF
--- a/js/Flotr.Axis.js
+++ b/js/Flotr.Axis.js
@@ -53,9 +53,6 @@ Axis.prototype = {
           minorTicks = o.minorTicks || [], 
           t, label;
 
-      cleanUserTicks(ticks, axis.ticks);
-      cleanUserTicks(minorTicks, axis.minorTicks);
-
       function cleanUserTicks (ticks, axisTicks) {
 
         if(_.isFunction(ticks)){
@@ -74,6 +71,9 @@ Axis.prototype = {
           axisTicks[i] = { v: v, label: label };
         }
       }
+
+      cleanUserTicks(ticks, axis.ticks);
+      cleanUserTicks(minorTicks, axis.minorTicks);
 
     }
     else {


### PR DESCRIPTION
move the function declaration before the calls. Apparently firefox desperately wants it that way. See http://stackoverflow.com/questions/4069100/why-cant-i-use-a-javascript-function-before-its-definition-inside-a-try-block.
