### PR TITLE
Fix missing reference in axis clean user ticks

### DIFF
--- a/js/Axis.js
+++ b/js/Axis.js
@@ -163,7 +163,7 @@ Axis.prototype = {
 
   _cleanUserTicks : function (ticks, axisTicks) {
 
-    var options = this.options,
+    var axis = this, options = this.options,
       v, i, label, tick;
 
     if(_.isFunction(ticks)) ticks = ticks({min : axis.min, max : axis.max});


### PR DESCRIPTION
There a reference to `axis.min` and `axis.max`, but `axis` is not defined.
