### PR TITLE
fire an event after initializing the graph's options

### DIFF
--- a/js/Graph.js
+++ b/js/Graph.js
@@ -582,8 +582,6 @@ Graph.prototype = {
     options.y2axis = _.extend(_.clone(options.yaxis), options.y2axis);
     this.options = flotr.merge(opts || {}, options);
 
-    this.axes = flotr.Axis.getAxes(this.options);
-
     if (this.options.grid.minorVerticalLines === null &&
       this.options.xaxis.scaling === 'logarithmic') {
       this.options.grid.minorVerticalLines = true;
@@ -592,6 +590,10 @@ Graph.prototype = {
       this.options.yaxis.scaling === 'logarithmic') {
       this.options.grid.minorHorizontalLines = true;
     }
+
+    E.fire(this.el, 'flotr:afterinitoptions', [this]);
+
+    this.axes = flotr.Axis.getAxes(this.options);
 
     // Initialize some variables used throughout this function.
     var assignedColors = [],


### PR DESCRIPTION
I'd like to be able to perform some last-minute changes to the options. This is not possible at the moment as the beforeinit event does not publish the passed options parameter (which would also be fine for my needs) and the afterconstruct has also used some of the values originally passed to the constructor.
