### PR TITLE
Fix potential memory leaks due to event observers not unbound in plugins

### DIFF
--- a/js/plugins/handles.js
+++ b/js/plugins/handles.js
@@ -11,7 +11,6 @@
 (function () {
 
 var D = Flotr.DOM,
-  E = Flotr.EventAdapter,
   o, s, el, container, left, right, scroll, delta, X,
   moveHandler;
 
@@ -51,10 +50,10 @@ function init() {
     D.insert(container, right);
     D.insert(container, left);
 
-    E.observe(left, 'mousedown', function () {
+    this._observe(left, 'mousedown', function () {
       moveHandler = leftMoveHandler;
     });
-    E.observe(right, 'mousedown', function () {
+    this._observe(right, 'mousedown', function () {
       moveHandler = rightMoveHandler;
     });
   }
@@ -63,12 +62,12 @@ function init() {
   if (o.scroll) {
     scroll = D.node('<div class="flotr-handles-handle flotr-handles-scroll"></div>');
     D.insert(container, scroll);
-    E.observe(scroll, 'mousedown', function () {
+    this._observe(scroll, 'mousedown', function () {
       moveHandler = scrollMoveHandler;
     });
   }
 
-  E.observe(document, 'mouseup', function() {
+  this._observe(document, 'mouseup', function() {
     moveHandler = null;
   });
 

--- a/js/plugins/spreadsheet.js
+++ b/js/plugins/spreadsheet.js
@@ -44,9 +44,9 @@ Flotr.addPlugin('spreadsheet', {
 
       D.setStyles(container, {top: this.canvasHeight-offset+'px'});
 
-      Flotr.EventAdapter.
-        observe(graph, 'click',  function(){ss.showTab('graph');}).
-        observe(data, 'click', function(){ss.showTab('data');});
+      this.
+        _observe(graph, 'click',  function(){ss.showTab('graph');}).
+        _observe(data, 'click', function(){ss.showTab('data');});
 
       return;
     }
@@ -180,9 +180,9 @@ Flotr.addPlugin('spreadsheet', {
       this.options.spreadsheet.toolbarSelectAll+
       '</button>');
 
-    Flotr.EventAdapter.
-      observe(buttonDownload, 'click', _.bind(this.spreadsheet.downloadCSV, this)).
-      observe(buttonSelect, 'click', _.bind(this.spreadsheet.selectAllData, this));
+    this.
+      _observe(buttonDownload, 'click', _.bind(this.spreadsheet.downloadCSV, this)).
+      _observe(buttonSelect, 'click', _.bind(this.spreadsheet.selectAllData, this));
 
     var toolbar = D.node('<div class="flotr-datagrid-toolbar"></div>');
     D.insert(toolbar, buttonDownload);


### PR DESCRIPTION
use this._observe instead of Flotr.EventAdapter.observe to observe events within plugins, this makes sure that they are cleaned up when the chart is destroyed
