### PR TITLE
Specify initial tab for spreadsheet

### DIFF
--- a/js/plugins/spreadsheet.js
+++ b/js/plugins/spreadsheet.js
@@ -219,6 +219,8 @@ Flotr.addPlugin('spreadsheet', {
         D.addClass(this.spreadsheet.tabs.data, 'selected');
         D.removeClass(this.spreadsheet.tabs.graph, 'selected');
       break;
+      default:
+        throw 'Illegal tab name: ' + tabName;
     }
     this.spreadsheet.activeTab = tabName;
   },


### PR DESCRIPTION
Added an option to the spreadsheet plugin to specify the initially visible tab ('graph' or 'data')
