### PR TITLE
Crosshair ghosting

### DIFF
--- a/js/Graph.js
+++ b/js/Graph.js
@@ -575,7 +575,7 @@ Graph.prototype = {
     this.ctx = getContext(this.canvas);
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     this.octx = getContext(this.overlay);
-    this.ctx.clearRect(0, 0, this.overlay.width, this.overlay.height);
+    this.octx.clearRect(0, 0, this.overlay.width, this.overlay.height);
     this.canvasHeight = size.height;
     this.canvasWidth = size.width;
     this.textEnabled = !!this.ctx.drawText || !!this.ctx.fillText; // Enable text functions


### PR DESCRIPTION
Hi,

I think I found a typo in Graph.js that meant that the overlay canvas wasnt being cleared.  Ive corrected the typo, chang this.ctx to be this.octx in _initCanvas function.  This stops the ghosting of the cross hair.

If Ive messed up the pull request I apologise, Im still getting the hang of git hub (and Flotr2)!

Thanks for making such a cool library :)

Steve
