### PR TITLE
Tweak to setSelection

### DIFF
--- a/js/plugins/selection.js
+++ b/js/plugins/selection.js
@@ -146,8 +146,8 @@ Flotr.addPlugin('selection', {
 
     s.first.y  = boundY((selX && !selY) ? 0 : (ya.max - area.y1) * vertScale, this);
     s.second.y = boundY((selX && !selY) ? this.plotHeight - 1: (ya.max - area.y2) * vertScale, this);
-    s.first.x  = boundX((selY && !selX) ? 0 : area.x1, this);
-    s.second.x = boundX((selY && !selX) ? this.plotWidth : area.x2, this);
+    s.first.x  = boundX((selY && !selX) ? 0 : (area.x1 - xa.min) * hozScale, this);
+    s.second.x = boundX((selY && !selX) ? this.plotWidth : (area.x2 - xa.min) * hozScale, this);
     
     this.selection.drawSelection();
     if (!preventEvent)


### PR DESCRIPTION
Carl,
It looks like there is a nit in setSelection that doesn't work quite right when programmatically selecting an area on a chart from outside of the chart (e.g., highlighting a main chart's viewed area on a thumbnail overview chart).  The attached changes appear to fix the issue. 
