### PR TITLE
Fix to the empty pie chart slice bug #107

### DIFF
--- a/js/types/pie.js
+++ b/js/types/pie.js
@@ -165,7 +165,7 @@ Flotr.addType('pie', {
     if (r < slice.radius + explode && r > explode) {
       if ((start > end && (theta < end || theta > start)) ||
         (theta > start && theta < end) ||
-		(start === end && Math.abs(theta - start) < epsilon)) {
+		(start === end && ((slice.start === slice.end && Math.abs(theta - start) < epsilon) || (slice.start !== slice.end && Math.abs(theta-start) > epsilon)))) {
 
         // TODO Decouple this from hit plugin (chart shouldn't know what n means)
          n.x = data[0];


### PR DESCRIPTION
Changed hit function to work correctly when start === end

NOTE: because your build system is mac-only, I couldn't build a new version of the combined files. I tested this by making the same change to the combined flotr2.js file.
