### PR TITLE
clear the reference to the mouseTrack div when cleaning up the chart

### DIFF
--- a/js/plugins/hit.js
+++ b/js/plugins/hit.js
@@ -17,7 +17,7 @@ Flotr.addPlugin('hit', {
     'flotr:mouseout': function() {
       this.hit.clearHit();
     },
-    'flotr:mouseout': function() {
+    'flotr:destroy': function() {
       this.mouseTrack = null;
     }
   },


### PR DESCRIPTION
The hit plugin holds a reference to a DOM element. This should be cleaned up when the chart is destroyed.
