### PR TITLE
remove left-over function names

### DIFF
--- a/js/Axis.js
+++ b/js/Axis.js
@@ -42,17 +42,17 @@ Axis.prototype = {
 
     // Logarithmic?
     if (logarithmic) {
-      this.d2p = function d2pLog (dataValue) {
+      this.d2p = function (dataValue) {
         return offset + orientation * (log(dataValue, options.base) - log(min, options.base)) * scale;
       }
-      this.p2d = function p2dLog (pointValue) {
+      this.p2d = function (pointValue) {
         return exp((offset + orientation * pointValue) / scale + log(min, options.base), options.base);
       }
     } else {
-      this.d2p = function d2p (dataValue) {
+      this.d2p = function (dataValue) {
         return offset + orientation * (dataValue - min) * scale;
       }
-      this.p2d = function p2d (pointValue) {
+      this.p2d = function (pointValue) {
         return (offset + orientation * pointValue) / scale + min;
       }
     }


### PR DESCRIPTION
The method names are left over from a previous refactoring
