### PR TITLE
only use the point type's settings in the hit plugin if the point type is available

### DIFF
--- a/js/plugins/hit.js
+++ b/js/plugins/hit.js
@@ -82,7 +82,7 @@ Flotr.addPlugin('hit', {
 
         octx.beginPath();
           // TODO fix this (points) should move to general testable graph mixin
-          octx.arc(xa.d2p(n.x), ya.d2p(n.y), s.points.hitRadius || s.points.radius || s.mouse.radius, 0, 2 * Math.PI, true);
+          octx.arc(xa.d2p(n.x), ya.d2p(n.y), (s.points ? s.points.hitRadius || s.points.radius : undefined) || s.mouse.radius, 0, 2 * Math.PI, true);
           octx.fill();
           octx.stroke();
         octx.closePath();
@@ -107,7 +107,7 @@ Flotr.addPlugin('hit', {
         var
           s = prev.series,
           lw = (s.points ? s.points.lineWidth : 1);
-          offset = (s.points.hitRadius || s.points.radius || s.mouse.radius) + lw;
+          offset = ((s.points ? s.points.hitRadius || s.points.radius : undefined) || s.mouse.radius) + lw;
         octx.clearRect(
           prev.xaxis.d2p(prev.x) - offset,
           prev.yaxis.d2p(prev.y) - offset,


### PR DESCRIPTION
The hit plugin cannot be used without the points type as the hit circle's sizes are computed based on the points type's options. See http://jsfiddle.net/VuUVu/. If we remove the points graph type, moving the mouse over the chart points causes a TypeError :"Cannot read property 'hitRadius' of undefined".
