### PR TITLE
Support for centrally-positioned legends

### DIFF
--- a/js/plugins/legend.js
+++ b/js/plugins/legend.js
@@ -74,8 +74,12 @@ Flotr.addPlugin('legend', {
         if(p.charAt(1) == 'e') offsetX = plotOffset.left + this.plotWidth - (m + legendWidth);
         
         // Legend box
-        color = this.processColor(legend.backgroundColor, {opacity: legend.backgroundOpacity || 0.1});
-        
+        opacity = 0.1;
+        if(legend.backgroundOpacity !== undefined && legend.backgroundOpacity !== null) {
+          opacity = legend.backgroundOpacity;
+        }
+        color = this.processColor(legend.backgroundColor, {opacity: opacity});
+            
         ctx.fillStyle = color;
         ctx.fillRect(offsetX, offsetY, legendWidth, legendHeight);
         ctx.strokeStyle = legend.labelBoxBorderColor;


### PR DESCRIPTION
This allows legends to be centrally positioned using the option `position: 'ce'` or `position: 'cw'`.

Only works for Canvas legend, not HTML version, as I couldn't work out how to calculate the margin offset for an HTML table.

Also this change is only in the src file, not the built version!
