### PR TITLE
Fixed Issue #122 east-west mixup + show tooltips for bar chart at the top

### DIFF
--- a/js/plugins/hit.js
+++ b/js/plugins/hit.js
@@ -302,11 +302,6 @@ Flotr.addPlugin('hit', {
       if      (p.charAt(1) == 'e') pos += 'right:' + (m + right) + 'px;left:auto;';
       else if (p.charAt(1) == 'w') pos += 'left:' + (m + left) + 'px;right:auto;';
 
-    // Bars
-    } else if (s.bars && s.bars.show) {
-        pos += 'bottom:' + (m - top - n.yaxis.d2p(n.y/2) + this.canvasHeight) + 'px;top:auto;';
-        pos += 'left:' + (m + left + n.xaxis.d2p(n.x - options.bars.barWidth/2)) + 'px;right:auto;';
-
     // Pie
     } else if (s.pie && s.pie.show) {
       var center = {
@@ -320,16 +315,15 @@ Flotr.addPlugin('hit', {
       pos += 'left:' + (m + left + center.x + Math.cos(bisection) * radius/2) + 'px;right:auto;';
 
     // Default
-    } else {
+    } else {    
       if (/n/.test(p)) pos += 'bottom:' + (m - top - n.yaxis.d2p(n.y) + this.canvasHeight) + 'px;top:auto;';
       else             pos += 'top:' + (m + top + n.yaxis.d2p(n.y)) + 'px;bottom:auto;';
-      if (/e/.test(p)) pos += 'right:' + (m - left - n.xaxis.d2p(n.x) + this.canvasWidth) + 'px;left:auto;';
+      if (/w/.test(p)) pos += 'right:' + (m - left - n.xaxis.d2p(n.x) + this.canvasWidth) + 'px;left:auto;';
       else             pos += 'left:' + (m + left + n.xaxis.d2p(n.x)) + 'px;right:auto;';
     }
 
     elStyle += pos;
     mouseTrack.style.cssText = elStyle;
-
     if (!decimals || decimals < 0) decimals = 0;
     
     if (x && x.toFixed) x = x.toFixed(decimals);


### PR DESCRIPTION
I'm migrating jquery flot library to flotr2 in reclinejs.com.

I think it's nicer to show the tooltip of bars at the top of the bar instead of in the middle. (the code to put the tooltip in the middle introducted a bug when the bars were horizontal as well)

Fixed Issue #122: there was a mixup with east and west in the default section.
