### PR TITLE
Fixed image blurring of markers

### DIFF
--- a/js/types/markers.js
+++ b/js/types/markers.js
@@ -127,7 +127,7 @@ Flotr.addType('markers', {
       context.strokeRect(left, top, dim.width, dim.height);
     
     if (isImage(label))
-      context.drawImage(label, parseInt(left+margin), parseInt(top+margin));
+      context.drawImage(label, parseInt(left+margin, 10), parseInt(top+margin, 10));
     else
       Flotr.drawText(context, label, left+margin, top+margin, {textBaseline: 'top', textAlign: 'left', size: options.fontSize, color: options.color});
   }


### PR DESCRIPTION
When position becomes a float the image is blurred. By using parseInt we force it to render properly and might even improve performance according to the article.

See http://www.html5rocks.com/en/tutorials/canvas/performance/#toc-avoid-float
