### PR TITLE
Fixed hard-coded default Hit fillSyle

### DIFF
--- a/js/plugins/hit.js
+++ b/js/plugins/hit.js
@@ -79,7 +79,7 @@ Flotr.addPlugin('hit', {
       octx.save();
       octx.lineWidth = (s.points ? s.points.lineWidth : 1);
       octx.strokeStyle = s.mouse.lineColor;
-      octx.fillStyle = this.processColor(s.mouse.fillColor || '#ffffff', {opacity: s.mouse.fillOpacity});
+      octx.fillStyle = this.processColor(s.mouse.fillColor || s.color, {opacity: s.mouse.fillOpacity});
       octx.translate(this.plotOffset.left, this.plotOffset.top);
 
       if (!this.hit.executeOnType(s, 'drawHit', n)) {


### PR DESCRIPTION
With this fix now one does not have to specify the desired color for every serie, which is more like the behavior of previous version.
