### PR TITLE
Add build without 3rd party libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ flotr2: libraries ie
 	cat build/flotr2.min.js >> flotr2.min.js
 	echo ';' >> flotr2.min.js
 	cp build/ie.min.js flotr2.ie.min.js
+	cat build/flotr2.js > flotr2.nolibs.js
 
 flotr2-basic: libraries ie
 	smoosh make/basic.json


### PR DESCRIPTION
This build expects to find Underscore and Bean libraries as globals by
the time it is loaded. This is very useful for those how want to take
greater control of the libraries used.

Using this build RequireJS and Browserify users can manually setup a
shim configs for Flotr2.

Here's something you might want to add to documentation:
## Browserify Example

`flotr2.shim.js`

``` javascript
// Expose Underscore and Bean as globals from npm
window._ = require("underscore");
window.bean = require("bean");

// Require Flotr2 expecting the globals
require("./flotr2.nolibs");

// Export it as a module for convenience
module.exports = window.Flotr;
```
## RequireJS Example

``` javascript
require.config({                                                                 
  shim: {                                                                       
    "flotr2": {                                                                                           
      deps: ["underscore", "bean"],                                              
      exports: "Flotr"                                                           
    },                                                                           
    "underscore": {                                                              
      exports: "_"                                                               
    }                                                                            
  },                                                                             
  paths: {                                                                       
    "flotr2": "vendor/flotr2.nolibs",                                           
    "underscore": "vendor/underscore",                                          
    "bean": "vendor/bean"                                                       
  }                                                                             
});
```

Bean is a AMD module so no need to shim it like Underscore.
