### PR TITLE
hide dummy div after measuring for issue #236

### DIFF
--- a/flotr2.js
+++ b/flotr2.js
@@ -2281,8 +2281,10 @@ Text.prototype = {
     D.setStyles(div, { 'position' : 'absolute', 'top' : '-10000px' });
     D.insert(div, '<div style="'+style+'" class="'+className+' flotr-dummy-div">' + text + '</div>');
     D.insert(this.o.element, div);
+    var dim = D.size(div);
+    D.hide(div);
 
-    return D.size(div);
+    return dim;
   },
 
   measureText : function (text, style) {


### PR DESCRIPTION
Judging by the number of places this html() function was defined in the source tree there are probably better ways to have done this commit but I'm not up to speed on the smoosh/jasmine toolchain and wasn't sure where to put it.
