### PR TITLE
fix duplicate var issue

### DIFF
--- a/js/Date.js
+++ b/js/Date.js
@@ -97,7 +97,7 @@ Flotr.Date = {
       ticks     = [],
       tickSize  = axis.tickSize,
       tickUnit,
-      formatter, i;
+      formatter, i, d;
 
     // Use custom formatter or time tick formatter
     formatter = (options.tickFormatter === Flotr.defaultTickFormatter ?
@@ -105,8 +105,8 @@ Flotr.Date = {
     );
 
     for (i = 0; i < spec.length - 1; ++i) {
-      var d = spec[i][0] * timeUnits[spec[i][1]];
-      if (delta < (d + spec[i+1][0] * timeUnits[spec[i+1][1]]) / 2 && d >= tickSize)
+      var date = spec[i][0] * timeUnits[spec[i][1]];
+      if (delta < (date + spec[i+1][0] * timeUnits[spec[i+1][1]]) / 2 && date >= tickSize)
         break;
     }
     tickSize = spec[i][0];


### PR DESCRIPTION
jshint reports the use of the undeclared var `d`.
I'm not entirely sure that the fix is correct. Apparently, the problem was introduced in d9fd6e16cdb68e605053857673b5f800ef459746 with the intention of fixing another jshint issue. As I understand it, that var `d` in the `for` loop shadows the variable `d` from the `generator` function, so I renamed it.
