### PR TITLE
Check for mouse events also on touch devices

### DIFF
--- a/js/Graph.js
+++ b/js/Graph.js
@@ -553,16 +553,17 @@ Graph.prototype = {
         }
         this.lastMousePos = pos;
       }, this));
-
-    } else {
-      this.
-        observe(this.overlay, 'mousedown', _.bind(this.mouseDownHandler, this)).
-        observe(el, 'mousemove', _.bind(this.mouseMoveHandler, this)).
-        observe(this.overlay, 'click', _.bind(this.clickHandler, this)).
-        observe(el, 'mouseout', function (e) {
-          E.fire(el, 'flotr:mouseout', e);
-        });
     }
+
+    // We should do this both for mouse-driven and touch devices.
+    // The user can use a mouse even if her device has touch capabilities.
+    this.
+      observe(this.overlay, 'mousedown', _.bind(this.mouseDownHandler, this)).
+      observe(el, 'mousemove', _.bind(this.mouseMoveHandler, this)).
+      observe(this.overlay, 'click', _.bind(this.clickHandler, this)).
+      observe(el, 'mouseout', function (e) {
+        E.fire(el, 'flotr:mouseout', e);
+      });
   },
 
   /**


### PR DESCRIPTION
Even if a device has touch capabilities (most modern laptops have) the user can still be using the device with a mouse. So install the mouse handler events also for touch-capable devices.

More info: https://hacks.mozilla.org/2013/04/detecting-touch-its-the-why-not-the-how/
